### PR TITLE
Adding Widgets integration (for Site Origin Page Builder)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Adds a shortcode to embed Romulus CRM contact forms on any Wordpress Page or Post.
+Adds a shortcode and widget to embed Romulus CRM contact forms on any Wordpress Page or Post.
 
 == Installation ==
 
@@ -32,3 +32,5 @@ Our team is always happy to help you install this plugin or any other integratio
 
 = 1.0 =
 * Added `romulus_contact_form` shortcode
+= 1.1 =
+* Added Romulus Contact Form widget

--- a/romulus-contact-form.php
+++ b/romulus-contact-form.php
@@ -14,7 +14,7 @@ function romulus_contact_form_shortcode_function( $attrs ) {
     $url = $attrs['url'];
     return '<iframe src="'.$url.'"
               width="520"
-              height="1090"
+              height="1590"
               frameborder="0"
               style="overflow: auto; padding: 14px; margin: 12px; width: 98%; max-width: 900px; background-color: #fff; border: none">
       </iframe>';
@@ -22,3 +22,59 @@ function romulus_contact_form_shortcode_function( $attrs ) {
 }
 
 add_shortcode('romulus_contact_form', 'romulus_contact_form_shortcode_function');
+
+// Creating the widget 
+class romulus_contact_form_widget extends WP_Widget {
+
+  function __construct() {
+    parent::__construct(
+    // Base ID of your widget
+    'wpb_widget', 
+
+    // Widget name will appear in UI
+    __('Romulus Contact Form', 'romulus_contact_form'), 
+
+    // Widget description
+    array( 'description' => __( 'Display a Romulus CRM contact form', 'romulus_contact_form' ), ) 
+    );
+  }
+
+  // Display the widget
+  public function widget( $args, $instance ) {   
+    echo romulus_contact_form_shortcode_function( $instance );
+  }
+      
+  // Widget form 
+  public function form( $instance ) {
+    $url = isset( $instance[ 'url' ] ) ? $instance[ 'url' ] : '';
+    ?>
+    <p>
+    <label for="<?php echo $this->get_field_id( 'url' ); ?>"><?php _e( 'Romulus Public Form URL:' ); ?></label> 
+    <input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>" />
+    </p>
+    <p><?php echo __('1. Login to Romulus <br/> 2. Go to Department Profile <br/>3. Copy your Public form url', 'romulus_contact_form'); ?><p>
+      <a href="<?php echo plugins_url( 'assets/screenshot-1.png', __FILE__ ); ?>" target="_blank">
+        <img 
+          src="<?php echo plugins_url( 'assets/screenshot-1.png', __FILE__ ); ?>" 
+          alt="<?php echo __('Click to see larger version. Screenshot of Romulus interface.', 'romulus_contact_form'); ?>" 
+          style="max-width:100%;height:auto;width:650px;"
+          />
+      </a>
+    </p>
+    <?
+  <?php 
+  }
+    
+  // Widget form submit
+  public function update( $new_instance, $old_instance ) {
+    $instance = array();
+    $instance['url'] = ( ! empty( $new_instance['url'] ) ) ? strip_tags( $new_instance['url'] ) : '';
+    return $instance;
+  }
+} // Class wpb_widget ends here
+
+// Register and load the widget
+function romulus_contact_form_load_widget() {
+  register_widget( 'romulus_contact_form_widget' );
+}
+add_action( 'widgets_init', 'romulus_contact_form_load_widget' );


### PR DESCRIPTION
This PR adds a "Romulus Contact Form" widget so Romulus forms can be added within Site Origin Page Builder, https://wordpress.org/plugins/siteorigin-panels/, or Wordpress Core Widgets interface. See https://proudcity.zendesk.com/hc/en-us/articles/226334587-Adding-a-Romulus-CRM-Form for screenshots.